### PR TITLE
Changes to avoid ConcurrentModificationExceptions.

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSCache.java
+++ b/src/main/java/javax/jmdns/impl/DNSCache.java
@@ -279,7 +279,7 @@ public class DNSCache extends ConcurrentHashMap<String, List<DNSEntry>> {
             aLog.append(key);
             aLog.append("' ");
             List<? extends DNSEntry> entryList = this.get(key);
-            if ((entryList != null) && (!entryList.isEmpty())) {
+            if (entryList != null) {
                 synchronized (entryList) {
                     for (DNSEntry entry : entryList) {
                         aLog.append("\n\t\t\t");

--- a/src/main/java/javax/jmdns/impl/JmDNSImpl.java
+++ b/src/main/java/javax/jmdns/impl/JmDNSImpl.java
@@ -876,21 +876,33 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
         this.waitForInfoData(info, timeout);
     }
 
-    void handleServiceResolved(ServiceEvent event) {
-        List<ServiceListenerStatus> list = _serviceListeners.get(event.getType().toLowerCase());
-        final List<ServiceListenerStatus> listCopy;
-        if ((list != null) && (!list.isEmpty())) {
+    /**
+     * Informs all registered {@link ServiceListener}s with an {@link ServiceEvent} about a resolved {@link ServiceInfo}.
+     *
+     * @param event
+     *            containing the {@link ServiceInfo} which was resolved
+     */
+    void handleServiceResolved(final ServiceEvent event) {
+        final List<ServiceListenerStatus> list = _serviceListeners.get(event.getType().toLowerCase());
+
+        // we might have some listeners to inform
+        if (list != null)  {
             if ((event.getInfo() != null) && event.getInfo().hasData()) {
-                final ServiceEvent localEvent = event;
+                final List<ServiceListenerStatus> listCopy;
                 synchronized (list) {
+                    if ( list.isEmpty() ) {
+                        // no listeners found => nothing to do
+                        return;
+                    }
                     listCopy = new ArrayList<ServiceListenerStatus>(list);
                 }
+
                 for (final ServiceListenerStatus listener : listCopy) {
                     _executor.submit(new Runnable() {
                         /** {@inheritDoc} */
                         @Override
                         public void run() {
-                            listener.serviceResolved(localEvent);
+                            listener.serviceResolved(event);
                         }
                     });
                 }
@@ -1120,27 +1132,33 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
             }
         }
         if (subtype.length() > 0) {
-            ServiceTypeEntry subtypes = _serviceTypes.get(loname);
-            if ((subtypes != null) && (!subtypes.contains(subtype))) {
+            final ServiceTypeEntry subtypes = _serviceTypes.get(loname);
+            if (subtypes != null) {
+                boolean needsSubTypeAddedNotification = false;
                 synchronized (subtypes) {
                     if (!subtypes.contains(subtype)) {
                         typeAdded = true;
                         subtypes.add(subtype);
-                        final ServiceTypeListenerStatus[] list = _typeListeners.toArray(new ServiceTypeListenerStatus[_typeListeners.size()]);
-                        final ServiceEvent event = new ServiceEventImpl(this, "_" + subtype + "._sub." + name, "", null);
-                        for (final ServiceTypeListenerStatus status : list) {
-                            _executor.submit(new Runnable() {
-                                /** {@inheritDoc} */
-                                @Override
-                                public void run() {
-                                    status.subTypeForServiceTypeAdded(event);
-                                }
-                            });
-                        }
+                        needsSubTypeAddedNotification = true;
+                    }
+                }
+                if (needsSubTypeAddedNotification) {
+                    // _typeListeners is already synchronized
+                    final List<ServiceTypeListenerStatus> list = new ArrayList<ServiceTypeListenerStatus>(_typeListeners);
+                    final ServiceEvent event = new ServiceEventImpl(this, "_" + subtype + "._sub." + name, "", null);
+                    for (final ServiceTypeListenerStatus status : list) {
+                        _executor.submit(new Runnable() {
+                            /** {@inheritDoc} */
+                            @Override
+                            public void run() {
+                                status.subTypeForServiceTypeAdded(event);
+                            }
+                        });
                     }
                 }
             }
         }
+
         return typeAdded;
     }
 


### PR DESCRIPTION
Some collections were accessed concurrently without being guarded by `synchronized`.