### PR TITLE
jmDNS release version 3.5.4.QC2

### DIFF
--- a/p2/features/org.jmdns.feature/feature.xml
+++ b/p2/features/org.jmdns.feature/feature.xml
@@ -1,7 +1,7 @@
 <feature
     id="org.jmdns.feature"
     label="JmDNS"
-    version="3.5.3.qualifier"
+    version="3.5.4.qualifier"
     provider-name="JmDNS.org">
 
     <description>

--- a/p2/features/org.jmdns.feature/feature.xml
+++ b/p2/features/org.jmdns.feature/feature.xml
@@ -1,7 +1,7 @@
 <feature
     id="org.jmdns.feature"
     label="JmDNS"
-    version="3.5.4.QC1"
+    version="3.5.4.QC2"
     provider-name="JmDNS.org">
 
     <description>

--- a/p2/features/org.jmdns.feature/pom.xml
+++ b/p2/features/org.jmdns.feature/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jmdns.p2</groupId>
         <artifactId>features</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.jmdns.feature</artifactId>

--- a/p2/features/org.jmdns.feature/pom.xml
+++ b/p2/features/org.jmdns.feature/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jmdns.p2</groupId>
         <artifactId>features</artifactId>
-        <version>3.5.4.QC1</version>
+        <version>3.5.4.QC2</version>
     </parent>
 
     <artifactId>org.jmdns.feature</artifactId>

--- a/p2/features/pom.xml
+++ b/p2/features/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jmdns.p2</groupId>
         <artifactId>pom</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>features</artifactId>

--- a/p2/features/pom.xml
+++ b/p2/features/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jmdns.p2</groupId>
         <artifactId>pom</artifactId>
-        <version>3.5.4.QC1</version>
+        <version>3.5.4.QC2</version>
     </parent>
 
     <artifactId>features</artifactId>

--- a/p2/pom.xml
+++ b/p2/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jmdns.p2</groupId>
     <artifactId>pom</artifactId>
-    <version>3.5.3-SNAPSHOT</version>
+    <version>3.5.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>JmDNS p2</name>

--- a/p2/pom.xml
+++ b/p2/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jmdns.p2</groupId>
     <artifactId>pom</artifactId>
-    <version>3.5.4.QC1</version>
+    <version>3.5.4.QC2</version>
     <packaging>pom</packaging>
 
     <name>JmDNS p2</name>

--- a/p2/repository/pom.xml
+++ b/p2/repository/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jmdns.p2</groupId>
         <artifactId>pom</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.jmdns.repository</artifactId>

--- a/p2/repository/pom.xml
+++ b/p2/repository/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jmdns.p2</groupId>
         <artifactId>pom</artifactId>
-        <version>3.5.4.QC1</version>
+        <version>3.5.4.QC2</version>
     </parent>
 
     <artifactId>org.jmdns.repository</artifactId>

--- a/p2/targetplatform/pom.xml
+++ b/p2/targetplatform/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jmdns.p2</groupId>
         <artifactId>pom</artifactId>
-        <version>3.5.4.QC1</version>
+        <version>3.5.4.QC2</version>
     </parent>
 
     <artifactId>targetplatform</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jmdns</groupId>
 	<artifactId>jmdns</artifactId>
-	<version>3.5.3-SNAPSHOT</version>
+	<version>3.5.4-SNAPSHOT</version>
 	<name>JmDNS</name>
 	<packaging>jar</packaging>
 	<description>JmDNS is a Java implementation of multi-cast DNS and can be used for service registration and discovery in local area networks. JmDNS is fully compatible with Apple's Bonjour.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jmdns</groupId>
 	<artifactId>jmdns</artifactId>
-	<version>3.5.4.QC1</version>
+	<version>3.5.4.QC2</version>
 	<name>JmDNS</name>
 	<packaging>jar</packaging>
 	<description>JmDNS is a Java implementation of multi-cast DNS and can be used for service registration and discovery in local area networks. JmDNS is fully compatible with Apple's Bonjour.

--- a/src/main/java/javax/jmdns/impl/JmDNSImpl.java
+++ b/src/main/java/javax/jmdns/impl/JmDNSImpl.java
@@ -464,6 +464,7 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
         _socket = new MulticastSocket(DNSConstants.MDNS_PORT);
         if ((hostInfo != null) && (hostInfo.getInterface() != null)) {
             final SocketAddress multicastAddr = new InetSocketAddress(_group, DNSConstants.MDNS_PORT);
+            _socket.setNetworkInterface(hostInfo.getInterface());
 
             logger.trace("Trying to joinGroup({}, {})", multicastAddr, hostInfo.getInterface());
 


### PR DESCRIPTION
* Cherry pick this commit, which fixes the network interface on IPv6 
https://github.com/jmdns/jmdns/commit/6a9e30f90bcfa1f83adefad739a01a9d1bb8d1dc
